### PR TITLE
fix: accommodate long log lines by using a scanner instead of readline to loop file

### DIFF
--- a/logv2.go
+++ b/logv2.go
@@ -183,18 +183,16 @@ func (ptr *Logv2) Analyze(filename string) error {
 		}
 	}
 
-	for { // check if it is in the logv2 format
-		if buf, _, err = reader.ReadLine(); err != nil { // 0x0A separator = newline
-			return errors.New("no valid log format found")
-		}
-		if len(buf) == 0 {
-			continue
-		}
-		str := string(buf)
+	// parse each line and validate it is in the logv2 format
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		str := scanner.Text()
 		if !regexp.MustCompile("^{.*}$").MatchString(str) {
 			return errors.New("log format not supported")
 		}
-		break
+	}
+	if _, err = file.Seek(0, 0); err != nil {
+		return err
 	}
 
 	if !ptr.legacy && ptr.s3client != nil {


### PR DESCRIPTION
This fixes #19

There is no issue with the log analyses because the isPrefix flag is taken into account and looped to build up a new buffer. The bug only existed with the validation which did not do the above.

This fix proposes to use a scanner to simplify file parsing, and resolve issues where the length of a log line would cause the file to fail validation incorrectly.