### PR TITLE
fix docker build and make container useful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.21-alpine as builder
 RUN apk update && apk add git bash build-base && rm -rf /var/cache/apk/* \
   && mkdir -p /github.com/simagix/hatchet && cd /github.com/simagix \
   && git clone --depth 1 https://github.com/simagix/hatchet.git
 WORKDIR /github.com/simagix/hatchet
-RUN ./build.sh
+RUN CGO_CFLAGS="-D_LARGEFILE64_SOURCE" go build -o ./dist/hatchet main/hatchet.go
+
 FROM alpine
 LABEL Ken Chen <ken.chen@simagix.com>
 RUN addgroup -S simagix && adduser -S simagix -G simagix
 USER simagix
 WORKDIR /home/simagix
-COPY --from=builder /github.com/simagix/hatchet/dist/hatchet /hatchet
-CMD ["/hatchet", "--version"]
+COPY --from=builder /github.com/simagix/hatchet/dist/hatchet /bin/hatchet
+
+CMD ["/bin/sh","-c","sleep infinity"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ Use the command below to process a log file, mongod.log.gz and start a web serve
 ./dist/hatchet -web logs/sample-mongod.log.gz
 ```
 
+## Docker
+If you wish to use it via docker you can run:
+```
+# this will look after the build and start container for you
+docker compose up -d 
+
+# this will give you a bash shell on the container so that you can run commands
+docker exec -it hatchet_container /bin/sh 
+
+in all commands you can just use `hatchet` instead of `./dist/hatchet` for example
+
+`hatchet -web logs/replica.tar.gz`
+
+any files in the logs folder on your system will be available in the container
+
+you can access http://localhost:3721 to view the hatchet web UI.
+
+to clean up run `docker compose down` it will stop the hatchet container and delete it
+```
+
 Load a file within a defined time range:
 ```bash
 ./dist/hatchet -web -from "2023-09-23T20:25:00" -to "2023-09-23T20:26:00" logs/sample-mongod.log.gz

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  hatchet:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: hatchet:latest
+    container_name: hatchet_container
+    volumes:
+      - ./logs:/home/simagix/logs
+    ports:
+      - "3721:3721" # so that http://localhost:3721/ will work


### PR DESCRIPTION
This makes a few changes:
1. Container runs go 1.21, instead of 1.19 which is now a requirement of hatchet
2. Container build is fixed for the musl error it previously showed
3. build now copies hatchet to /bin in the container so you can just call `hatchet` instead of `./dist/hatchet` each time
4. docker-compose file is included which will run the build if required, map port 3721 and mount ./logs into the container
5. README.md updated to include docker compose instructions and example
